### PR TITLE
Preencher Cod_UF com o código (numérico) da UF

### DIFF
--- a/R/abrir_base_estado.R
+++ b/R/abrir_base_estado.R
@@ -1,4 +1,4 @@
-abrir_base_estado <- function(base, estado, censodir = "~/Downloads/Censo2010/") {
+abrir_base_estado <- function(base, estado, censo_dir = "~/Downloads/Censo2010/") {
   arquivo <- file.path(censo_dir, paste0(base, "_", estado, ".xls"))
 
   b <- readxl::read_excel(arquivo, na = "X")

--- a/R/abrir_base_estado.R
+++ b/R/abrir_base_estado.R
@@ -1,7 +1,8 @@
 abrir_base_estado <- function(base, estado, censodir = "~/Downloads/Censo2010/") {
   arquivo <- file.path(censo_dir, paste0(base, "_", estado, ".xls"))
+
   b <- readxl::read_excel(arquivo, na = "X")
-  print(paste(estado, base, arquivo))
+
   b %>%
     # fix Entorno03
     mutate(Cod_UF = estado) %>%

--- a/R/abrir_base_estado.R
+++ b/R/abrir_base_estado.R
@@ -7,7 +7,7 @@ abrir_base_estado <- function(base, estado, censo_dir = "~/Downloads/Censo2010/"
     # fix Basico: substitui Cod_UF pelo código (numérico)
     # Assume que Cod_meso sempre existe na base em que Cod_UF existe e
     # toma os 2 primeiros dígitos de um número de 4 dígitos
-    mutate( across(any_of(Cod_UF), Cod_meso %/% 100) ) %>%
+    mutate( across(any_of("Cod_UF"), ~ Cod_meso %/% 100) ) %>%
     # fix Responsavel02_SP2
     mutate(across(starts_with("V"), as.numeric))
 }

--- a/R/abrir_base_estado.R
+++ b/R/abrir_base_estado.R
@@ -4,8 +4,10 @@ abrir_base_estado <- function(base, estado, censo_dir = "~/Downloads/Censo2010/"
   b <- readxl::read_excel(arquivo, na = "X")
 
   b %>%
-    # fix Entorno03
-    mutate(Cod_UF = estado) %>%
+    # fix Basico: substitui Cod_UF pelo código (numérico)
+    # Assume que Cod_meso sempre existe na base em que Cod_UF existe e
+    # toma os 2 primeiros dígitos de um número de 4 dígitos
+    mutate( across(any_of(Cod_UF), Cod_meso %/% 100) ) %>%
     # fix Responsavel02_SP2
     mutate(across(starts_with("V"), as.numeric))
 }


### PR DESCRIPTION
Algumas bases do IBGE são preenchidas com o código numérico da UF, e outras com a sigla da UF (string).

Esta PR substitui o valor de `Cod_UF` com o código numérico. O algoritmo retira os dois primeiros dígitos de `Cod_meso` (assume que esta variável tem sempre 4 dígitos).

O algoritmo é executado condicionalmente, quando `Cod_UF` existe na base (apenas `Basico`?), e é ignorado nas outras bases.

Clsoe #9